### PR TITLE
Compile against alt (musl) libc 

### DIFF
--- a/configure
+++ b/configure
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 # compile some test code
+# based on https://github.com/tvheadend/tvheadend/
 #
 check_func () {
   	local OUTP=tst-$1

--- a/configure
+++ b/configure
@@ -1,5 +1,42 @@
 #!/bin/sh
 
+# compile some test code
+#
+check_func () {
+  	local OUTP=tst-$1
+  	local SEG=$2
+  	local DEF=$3
+
+	cat << EOF > $OUTP.c
+$SEG
+int main() {
+#ifndef TEST
+  return test();
+#else
+  return 1;
+#endif
+}
+EOF
+	if [ -f $OUTP.c ]
+	then
+		gcc $OUTP.c -o $OUTP.bin > /dev/null 2>&1
+		if [ $? -eq 0 ]
+		then
+			sed -ri "s/EXTRACFLAGS\=(.*)/EXTRACFLAGS=\1 -D$DEF/" Makefile
+			rm -f $OUTP.c $OUTP.bin
+			return 0
+		fi
+		rm -f $OUTP.c
+		return 1
+
+	else
+		echo "Not found: $OUTP.c"
+	fi
+	return 1
+}
+
+
+
 # OS determination
 if [ x$1 != x ]; then
 UNAME=$1
@@ -13,14 +50,33 @@ FreeBSD | OpenBSD | NetBSD | DragonFly | BSD)
 	echo "${UNAME} system detected, Makefile created."
 	echo "Use make or make qwfwd-dl to build."
 	;;
+
 Darwin | MacOSX | Linux | SunOS | GNU | CYGWIN_*)
 	cat Makefile.GNU > Makefile
 	echo "${UNAME} system detected, Makefile created."
 	echo "Use make or make qwfwd-dl/qwfwd-dl32 to build."
+
+	echo "Checking for strlcpy support (e.g. musl libc)"
+	check_func strlcpy '#include <string.h>
+	#define TEST
+	int test(int argc, char **argv) {
+	char dst[10];
+	strlcpy("test", dst, sizeof(dst));
+	return 0;
+	}' USE_LIBC_STRLCPY
+
+	echo "Checking for strlcat support (e.g. musl libc)"
+	check_func strlcat '#include <string.h>
+	#define TEST
+	int test(int argc, char **argv) {
+	char dst[10];
+	strlcat("test", dst, sizeof(dst));
+	return 0;
+	}' USE_LIBC_STRLCAT
 	;;
+
 *)
 	echo "ERROR: Unknown system: ${UNAME}."
 	exit 1
 	;;
 esac
-

--- a/qwfwd.h
+++ b/qwfwd.h
@@ -319,14 +319,19 @@ int			qvsnprintf(char *buffer, size_t count, const char *format, va_list argptr)
 #define		snprintf		qsnprintf
 #define		vsnprintf		qvsnprintf
 
-#endif
+#endif // _WIN32
 
 #if defined(__linux__) || defined(_WIN32) || defined(__CYGWIN__)
 
+#ifndef USE_LIBC_STRLCPY
 size_t			strlcpy (char *dst, const char *src, size_t siz);
-size_t			strlcat (char *dst, char *src, size_t siz);
-
 #endif
+
+#ifndef USE_LIBC_STRLCAT
+size_t			strlcat (char *dst, char *src, size_t siz);
+#endif
+
+#endif // defined(__linux__) || defined(_WIN32) || defined(__CYGWIN__)
 
 void			Sys_Printf (char *fmt, ...);
 void			Sys_DPrintf(char *fmt, ...);

--- a/sys.c
+++ b/sys.c
@@ -49,6 +49,7 @@ int qvsnprintf(char *buffer, size_t count, const char *format, va_list argptr)
  *
  *  // VVD
  */
+#ifndef USE_LIBC_STRLCPY
 size_t strlcpy(char *dst, const char *src, size_t siz)
 {
 	register char *d = dst;
@@ -77,7 +78,9 @@ size_t strlcpy(char *dst, const char *src, size_t siz)
 
 	return(s - src - 1);	/* count does not include NUL */
 }
+#endif // USE_LIBC_STRLCPY
 
+#ifndef USE_LIBC_STRLCAT
 size_t strlcat(char *dst, char *src, size_t siz)
 {
 	register char *d = dst;
@@ -106,6 +109,7 @@ size_t strlcat(char *dst, char *src, size_t siz)
 
 	return(dlen + (s - src));       /* count does not include NUL */
 }
+#endif // USE_LIBC_STRLCAT
 
 #endif // defined(__linux__) || defined(_WIN32) || defined(__CYGWIN__)
 


### PR DESCRIPTION
Use builtin strlcpy and strlcat when available in alt libc implementations, this will now compile on Alpine Linux since they have moved to musl libc