### PR TITLE
Fix userinfo color

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ src/Makefile.dl32
 src/Makefile.vm
 qwfwd.bin
 qwfwd.db
+build/

--- a/src/peer.c
+++ b/src/peer.c
@@ -20,6 +20,17 @@ peer_t	*FWD_peer_by_addr(struct sockaddr_in *from)
 	return NULL;
 }
 
+static int parse_color(const char *userinfo, const char *key)
+{
+	char tmp[MAX_INFO_STRING];
+	int color;
+
+	Info_ValueForKey(userinfo, key, tmp, sizeof(tmp));
+	color = atoi(tmp);
+
+	return (color < 0) ? 0 : ((color > 16) ? 16 : color);
+}
+
 peer_t	*FWD_peer_new(const char *remote_host, int remote_port, struct sockaddr_in *from, const char *userinfo, int qport, protocol_t proto, qbool link)
 {
 	peer_t *p;
@@ -60,6 +71,8 @@ peer_t	*FWD_peer_new(const char *remote_host, int remote_port, struct sockaddr_i
 	p->proto	= proto;
 	strlcpy(p->userinfo, userinfo, sizeof(p->userinfo));
 	Info_ValueForKey(userinfo, "name", p->name, sizeof(p->name));
+	p->top          = parse_color(userinfo, "topcolor");
+	p->bottom       = parse_color(userinfo, "bottomcolor");
 	p->userid	= ( new_peer ) ? ++userid : p->userid; // do not bump userid in case of peer reusing
 
 	time(&p->last);

--- a/src/qwfwd.h
+++ b/src/qwfwd.h
@@ -149,6 +149,8 @@ typedef struct peer
 	int challenge;					// challenge num
 	char userinfo[MAX_INFO_STRING]; // userinfo
 	char name[MAX_INFO_KEY];		// name, extracted from userinfo
+	int top;
+	int bottom;
 	int userid;						// unique per proxy userid
 	int qport;						// qport
 	struct sockaddr_in from;		// client addr

--- a/src/svc.c
+++ b/src/svc.c
@@ -367,10 +367,8 @@ static void SVC_Status (void)
 	{
 		for (cl = peers; cl; cl = cl->next)
 		{
-			top    = 0;//Q_atoi(Info_Get (&cl->_userinfo_ctx_, "topcolor"));
-			bottom = 0;//Q_atoi(Info_Get (&cl->_userinfo_ctx_, "bottomcolor"));
-			top    = (top    < 0) ? 0 : ((top    > 13) ? 13 : top);
-			bottom = (bottom < 0) ? 0 : ((bottom > 13) ? 13 : bottom);
+			top    = cl->top;
+			bottom = cl->bottom;
 			ping   = 666; //SV_CalcPing (cl);
 			name   = cl->name;
 			skin   = "";


### PR DESCRIPTION
The bottomcolor and topcolor information was previously hardcoded to 0.

This commit extracts the colors from the userinfo string and sets them
accordingly so that the correct colors are reported when a
connectionless status command is received.
