### PR TITLE
Add more CVAR_SERVERINFO variables

### DIFF
--- a/resources/example-configs/qwfwd.cfg
+++ b/resources/example-configs/qwfwd.cfg
@@ -1,8 +1,16 @@
 // This is the default QWFWD configuration file
 // Feel free to change parameters to your liking
 
-// Hostname shows to connecting clients ingame
+// Hostname shown to connecting clients in-game
 set hostname QWFWD
+
+// Domain (or ip) and port number
+// set hostport "example.com:30000"
+
+// Geographical info
+// set countrycode "se"
+// set city "Stockholm"
+// set coords "59.3327,18.0656"
 
 // UDP port on which QWFWD will listen for client, default port is 30000
 // set net_port 30000

--- a/src/main.c
+++ b/src/main.c
@@ -15,6 +15,10 @@ cvar_t *developer;
 cvar_t *version;
 cvar_t *hostname;
 cvar_t *maxclients;
+cvar_t *hostport;
+cvar_t *countrycode;
+cvar_t *city;
+cvar_t *coords;
 
 proxy_static_t ps;
 
@@ -116,6 +120,10 @@ DWORD WINAPI FWD_proc(void *lpParameter)
 	version			= Cvar_Get("*version",		QWFWD_VERSION, CVAR_READONLY | CVAR_SERVERINFO);
 	hostname		= Cvar_Get("hostname",		"unnamed qwfwd", CVAR_SERVERINFO);
 	maxclients		= Cvar_Get("maxclients",	"128", CVAR_SERVERINFO);
+	hostport		= Cvar_Get("hostport",		"", CVAR_SERVERINFO);
+	countrycode		= Cvar_Get("countrycode",	"", CVAR_SERVERINFO);
+	city			= Cvar_Get("city",		"", CVAR_SERVERINFO);
+	coords			= Cvar_Get("coords",		"", CVAR_SERVERINFO);
 
 	// register basic commands
 	Cmd_AddCommand("quit", Cmd_Quit_f);

--- a/src/qwfwd.h
+++ b/src/qwfwd.h
@@ -224,6 +224,7 @@ typedef struct proxy_static_s
 extern proxy_static_t ps;
 
 extern cvar_t *developer, *maxclients, *hostname;
+extern cvar_t *hostport, *countrycode, *city, *coords;
 
 //
 // token.c


### PR DESCRIPTION
The following variables has been added:
- hostport
- countrycode
- city
- coords

As requested by Xantom