### PR TITLE
Add destination IP whitelist

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ set(SRC_COMMON
     "${DIR_SRC}/svc.c"
     "${DIR_SRC}/sys.c"
     "${DIR_SRC}/token.c"
+    "${DIR_SRC}/whitelist.c"
 	)
 
 

--- a/src/main.c
+++ b/src/main.c
@@ -129,6 +129,8 @@ DWORD WINAPI FWD_proc(void *lpParameter)
 	Cmd_AddCommand("quit", Cmd_Quit_f);
 	Cmd_AddCommand("serverinfo", SV_Serverinfo_f);
 
+	Whitelist_Init();
+
 	// now exec our cfg
 	Cbuf_InsertText ("exec qwfwd.cfg\n");
 	Cbuf_Execute();

--- a/src/peer.c
+++ b/src/peer.c
@@ -41,6 +41,9 @@ peer_t	*FWD_peer_new(const char *remote_host, int remote_port, struct sockaddr_i
 	if (!NET_GetSockAddrIn_ByHostAndPort(&to, remote_host, remote_port))
 		return NULL; // failed to resolve host name?
 
+	if (!SV_IsWhitelisted(&to))
+		return NULL;
+
 	// check for bans.
 	if (SV_IsBanned(&to))
 		return NULL;

--- a/src/qwfwd.h
+++ b/src/qwfwd.h
@@ -464,6 +464,10 @@ void				SV_CleanBansIPList(void);
 // Return true if add is banned.
 qbool				SV_IsBanned (struct sockaddr_in *addr);
 
+// Whitelist system.
+void Whitelist_Init(void);
+qbool SV_IsWhitelisted(struct sockaddr_in *addr);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/whitelist.c
+++ b/src/whitelist.c
@@ -1,0 +1,137 @@
+#include "qwfwd.h"
+
+#define WHITELIST_MAX_ADDRS 4096
+
+static int whitelist_count;
+static unsigned int whitelist[WHITELIST_MAX_ADDRS];
+
+static void Cmd_Whitelist_f (void);
+static void Cmd_WhitelistAdd_f (void);
+static void Cmd_WhitelistRemove_f (void);
+
+void Whitelist_Init(void)
+{
+	whitelist_count = 0;
+
+	Cmd_AddCommand("whitelist", Cmd_Whitelist_f);
+	Cmd_AddCommand("whitelistadd", Cmd_WhitelistAdd_f);
+	Cmd_AddCommand("whitelistremove", Cmd_WhitelistRemove_f);
+}
+
+qbool SV_IsWhitelisted(struct sockaddr_in *addr)
+{
+	int i;
+
+	if (!whitelist_count)
+	{
+		return true;
+	}
+
+	for (i = 0; i < whitelist_count; i++)
+	{
+		if (addr->sin_addr.s_addr == whitelist[i])
+		{
+			Sys_DPrintf("connection from %s allowed: address found in whitelist\n",
+				inet_ntoa(addr->sin_addr));
+			return true;
+		}
+	}
+
+	Sys_DPrintf("connection from %s dropped: address NOT in whitelist\n",
+		inet_ntoa(addr->sin_addr));
+	return false;
+}
+
+static void Cmd_Whitelist_f(void)
+{
+	struct in_addr addr;
+	int i;
+
+	Sys_Printf("whitelist: %d addresses\n", whitelist_count);
+
+	for (i = 0; i < whitelist_count; i++)
+	{
+		addr.s_addr = whitelist[i];
+		Sys_Printf("%s\n", inet_ntoa(addr));
+	}
+}
+
+static void Cmd_WhitelistAdd_f(void)
+{
+	char *ip_str;
+	int ip;
+	int i;
+
+	if (Cmd_Argc() != 2)
+	{
+		Sys_Printf("usage: whitelistadd <ip>\n");
+		return;
+	}
+
+	if (whitelist_count >= WHITELIST_MAX_ADDRS)
+	{
+		Sys_Printf("error: whitelist is full\n");
+		return;
+	}
+
+	ip_str = Cmd_Argv(1);
+
+	ip = inet_addr(ip_str);
+	if (ip == INADDR_NONE)
+	{
+		Sys_Printf("error: invalid IP address %s\n", ip_str);
+		return;
+	}
+
+	for (i = 0; i < whitelist_count; i++)
+	{
+		if (ip == whitelist[i])
+		{
+			Sys_Printf("error: %s has already been added to the whitelist\n", ip_str);
+			return;
+		}
+	}
+
+	whitelist[whitelist_count++] = ip;
+}
+
+
+static void Cmd_WhitelistRemove_f(void)
+{
+	char *ip_str;
+	int ip;
+	int i;
+	int j;
+
+	if (Cmd_Argc() != 2)
+	{
+		Sys_Printf("usage: whitelistremove <ip>\n");
+		return;
+	}
+
+	ip_str = Cmd_Argv(1);
+
+	ip = inet_addr(ip_str);
+	if (ip == INADDR_NONE)
+	{
+		Sys_Printf("error: invalid IP address %s\n", ip_str);
+		return;
+	}
+
+	for (i = 0; i < whitelist_count; i++)
+	{
+		if (whitelist[i] == ip)
+		{
+			for (j = i; j < whitelist_count - 1; j++)
+			{
+				whitelist[j] = whitelist[j + 1];
+			}
+
+			whitelist_count--;
+			Sys_Printf("%s removed from whitelist\n", ip_str);
+			return;
+		}
+	}
+
+	Sys_Printf("error: %s not found in whitelist\n", ip_str);
+}


### PR DESCRIPTION
This change adds a whitelist to control which destination IP addresses QWFWD is allowed to forward traffic to. If the whitelist is empty, all destinations are allowed.

New commands:

- whitelist
Lists the current whitelist entries.

- whitelistadd <ip>
Adds an IP address to the whitelist.

- whitelistremove <ip>
Removes an IP address from the whitelist.