### PR TITLE
Reload on SIGHUP

### DIFF
--- a/src/peer.c
+++ b/src/peer.c
@@ -219,7 +219,18 @@ static void FWD_network_update(void)
 	/* Sleep for some time, wake up immidiately if there input packet. */
 	tv.tv_sec = 0;
 	tv.tv_usec = 100000; // 100 ms
+
+retry:
 	retval = select(i1, &rfds, (fd_set *)0, (fd_set *)0, &tv);
+	if (retval < 0)
+	{
+		if (errno == EINTR)
+		{
+			goto retry;
+		}
+		perror("select");
+		return;
+	}
 
 	// read console input.
 	// NOTE: we do not do that if we are in DLL mode...

--- a/src/qwfwd.h
+++ b/src/qwfwd.h
@@ -466,6 +466,7 @@ qbool				SV_IsBanned (struct sockaddr_in *addr);
 
 // Whitelist system.
 void Whitelist_Init(void);
+void Cmd_WhitelistPurge_f (void);
 qbool SV_IsWhitelisted(struct sockaddr_in *addr);
 
 #ifdef __cplusplus

--- a/src/whitelist.c
+++ b/src/whitelist.c
@@ -16,6 +16,7 @@ void Whitelist_Init(void)
 	Cmd_AddCommand("whitelist", Cmd_Whitelist_f);
 	Cmd_AddCommand("whitelistadd", Cmd_WhitelistAdd_f);
 	Cmd_AddCommand("whitelistremove", Cmd_WhitelistRemove_f);
+	Cmd_AddCommand("whitelistpurge", Cmd_WhitelistPurge_f);
 }
 
 qbool SV_IsWhitelisted(struct sockaddr_in *addr)
@@ -134,4 +135,10 @@ static void Cmd_WhitelistRemove_f(void)
 	}
 
 	Sys_Printf("error: %s not found in whitelist\n", ip_str);
+}
+
+void Cmd_WhitelistPurge_f(void)
+{
+	whitelist_count = 0;
+	memset(whitelist, 0, WHITELIST_MAX_ADDRS * sizeof(unsigned int));
 }


### PR DESCRIPTION
When qwfwd receives a SIGHUP signal, it signals the application to reload the configuration. In effect, SIGHUP triggers "exec qwfwd.cfg". This functionality is not supported on Windows.

Additionally, SIGHUP purges the entire whitelist so that the configuration reload can reinitialize the addresses in the whitelist.

It is also possible to purge the whitelist manually by running the "whitelistpurge" command.