### PR TITLE
feat: Add PathProbe (best-path source port selection)

### DIFF
--- a/src/clc.c
+++ b/src/clc.c
@@ -9,7 +9,7 @@ static void CL_SendConnectPacket_QW(peer_t *p)
 	char data[2048];
 	char biguserinfo[MAX_INFO_STRING + 32];
 
-	if (p->ps != ps_challenge)
+	if (p->ps != ps_challenge && p->ps != ps_connecting)
 		return;
 
 	// Let the server know what extensions we support.
@@ -107,7 +107,7 @@ static void CL_SendConnectPacket_Q3(peer_t *p)
 	char biguserinfo[MAX_INFO_STRING + 100];
 	sizebuf_t msg;
 
-	if (p->ps != ps_challenge)
+	if (p->ps != ps_challenge && p->ps != ps_connecting)
 		return;
 
 	// add challenge to the temporary userinfo
@@ -147,7 +147,7 @@ static qbool CL_ConnectionlessPacket_Q3 (peer_t *p)
 	// challenge from the server we are connecting to
 	if ( !stricmp(c, "challengeResponse") )
 	{
-		if ( p->ps != ps_challenge )
+		if (p->ps != ps_challenge && p->ps != ps_connecting)
 		{
 			Sys_DPrintf( "Unwanted challenge response received.  Ignored.\n" );
 		}
@@ -177,7 +177,7 @@ static qbool CL_ConnectionlessPacket_Q3 (peer_t *p)
 			return need_forward;
 		}
 
-		if ( p->ps != ps_challenge )
+		if (p->ps != ps_challenge && p->ps != ps_connecting)
 		{
 			Sys_DPrintf ("connectResponse packet while not connecting.  Ignored.\n");
 			return need_forward;

--- a/src/main.c
+++ b/src/main.c
@@ -132,6 +132,10 @@ DWORD WINAPI FWD_proc(void *lpParameter)
 	city			= Cvar_Get("city",		"", CVAR_SERVERINFO);
 	coords			= Cvar_Get("coords",		"", CVAR_SERVERINFO);
 
+	sv_pathprobe_enable = Cvar_Get("sv_pathprobe_enable", "1", 0);
+	sv_pathprobe_count  = Cvar_Get("sv_pathprobe_count",  "3", 0);
+	sv_pathprobe_delay  = Cvar_Get("sv_pathprobe_delay",  "1000", 0);
+
 	// register basic commands
 	Cmd_AddCommand("quit", Cmd_Quit_f);
 	Cmd_AddCommand("serverinfo", SV_Serverinfo_f);

--- a/src/peer.c
+++ b/src/peer.c
@@ -24,6 +24,14 @@ static int GetGlobalProbeSocketsOpen(void) {
 
 #define MAX_TOTAL_PROBE_SOCKETS 64
 
+// Records which peer (and which of its probe sockets, if any) owns each entry
+// of the pollfd array, so readiness can be handed back to the owner by pointer
+// instead of by array position. See FWD_network_update().
+typedef struct {
+	peer_t  *peer;
+	probe_t *probe; // NULL when the entry is the peer's main socket
+} pfd_owner_t;
+
 static const char probe_payload_qw[] = {0xff, 0xff, 0xff, 0xff, 'p', 'i', 'n', 'g', '\n'};
 static const char probe_payload_gen[] = {A2A_PING, 0};
 
@@ -370,10 +378,12 @@ select_best:
   p->connect = 0;
 }
 
-// Process incoming packets on probe sockets
-static void FWD_ProcessProbes(peer_t *p, net_pollfd_t *pfds) {
+// Process incoming packets on probe sockets.
+// Readiness comes from probes[i].revents, which FWD_network_update() copied out
+// of the pollfd array right after qpoll(). Do NOT index a pollfd array by
+// position here: the peer list can change while we are draining net_socket.
+static void FWD_ProcessProbes(peer_t *p) {
   int i;
-  int current_probe_pfd = 0;
   const void *payload;
   int payload_len;
 
@@ -387,7 +397,7 @@ static void FWD_ProcessProbes(peer_t *p, net_pollfd_t *pfds) {
 
   for (i = 0; i < p->num_probes; i++) {
     if (p->probes[i].s != INVALID_SOCKET) {
-      if (pfds[current_probe_pfd].revents & POLLIN) {
+      if (p->probes[i].revents & POLLIN) {
         if (NET_GetPacket(p->probes[i].s, &net_message)) {
           if (NET_CompareAddress(&p->to, &net_from)) {
             // Any reply from the server on the probe socket is enough to
@@ -413,13 +423,13 @@ static void FWD_ProcessProbes(peer_t *p, net_pollfd_t *pfds) {
           }
         }
       }
-      current_probe_pfd++;
     }
   }
 }
 
 static void FWD_network_update(void) {
   net_pollfd_t *pfds = NULL;
+  pfd_owner_t *owners = NULL;
   int nfds = 0;
   int max_fds = 2; // net + stdin
   int retval;
@@ -427,10 +437,15 @@ static void FWD_network_update(void) {
   int stdin_idx = -1;
   peer_t *p;
   int i;
-  int current_pfd_idx;
 
-  // Calculate max FDs needed
+  // Calculate max FDs needed, and clear stale readiness from the previous
+  // iteration so a peer we do not poll this time never looks ready.
   for (p = peers; p; p = p->next) {
+    p->revents = 0;
+    for (i = 0; i < p->num_probes; i++) {
+      p->probes[i].revents = 0;
+    }
+
     if (p->ps == ps_pingprobe) {
       max_fds += p->num_probes;
     } else {
@@ -439,6 +454,9 @@ static void FWD_network_update(void) {
   }
 
   pfds = Sys_malloc(sizeof(net_pollfd_t) * max_fds);
+  // owners[i] records who owns pfds[i]. Sys_malloc() zeroes, so entries we
+  // never fill in (net_socket, stdin) stay { NULL, NULL } and are skipped.
+  owners = Sys_malloc(sizeof(pfd_owner_t) * max_fds);
 
   // select on main server socket
   pfds[nfds].fd = net_socket;
@@ -449,18 +467,22 @@ static void FWD_network_update(void) {
   for (p = peers; p; p = p->next) {
     // select on peers sockets
     if (p->ps == ps_pingprobe) {
-      for (i = 0; i < p->num_probes; i++) {
+      for (i = 0; i < p->num_probes && nfds < max_fds; i++) {
         if (p->probes[i].s != INVALID_SOCKET) {
           pfds[nfds].fd = p->probes[i].s;
           pfds[nfds].events = POLLIN;
           pfds[nfds].revents = 0;
+          owners[nfds].peer = p;
+          owners[nfds].probe = &p->probes[i];
           nfds++;
         }
       }
-    } else {
+    } else if (nfds < max_fds) {
       pfds[nfds].fd = p->s;
       pfds[nfds].events = POLLIN;
       pfds[nfds].revents = 0;
+      owners[nfds].peer = p;
+      owners[nfds].probe = NULL;
       nfds++;
     }
   }
@@ -469,7 +491,7 @@ static void FWD_network_update(void) {
 #ifndef APP_DLL
 #ifndef _WIN32
   // try read stdin only if connected to a terminal.
-  if (isatty(STDIN) && isatty(STDOUT)) {
+  if (isatty(STDIN) && isatty(STDOUT) && nfds < max_fds) {
     pfds[nfds].fd = STDIN;
     pfds[nfds].events = POLLIN;
     pfds[nfds].revents = 0;
@@ -485,8 +507,22 @@ retry:
       goto retry;
     }
     perror("poll");
+    Sys_free(owners);
     Sys_free(pfds);
     return;
+  }
+
+  // Copy readiness out of pfds and onto the owning peer/probe *now*, while the
+  // pfds <-> peers mapping is still valid. Draining net_socket below can create
+  // new peers (SVC_DirectConnect() -> FWD_peer_new() prepends to 'peers') and
+  // can move an existing peer into ps_pingprobe with a different socket count,
+  // so any later walk of 'peers' no longer lines up with pfds positionally.
+  for (i = 0; i < nfds; i++) {
+    if (owners[i].probe) {
+      owners[i].probe->revents = pfds[i].revents;
+    } else if (owners[i].peer) {
+      owners[i].peer->revents = pfds[i].revents;
+    }
   }
 
   // read console input.
@@ -565,24 +601,21 @@ retry:
     }
   }
 
-  // now lets check peers sockets, perhaps we have input packets too
-  current_pfd_idx = 1; // skip net_socket
+  // now lets check peers sockets, perhaps we have input packets too.
+  // NOTE: readiness is read from p->revents / p->probes[].revents, never by
+  // indexing pfds here - 'peers' may have grown since pfds was built.
+  // A peer created during this iteration has revents == 0 (Sys_malloc() zeroes)
+  // and is simply picked up on the next pass.
   for (p = peers; p; p = p->next) {
     if (p->ps == ps_pingprobe) {
-      FWD_ProcessProbes(p, &pfds[current_pfd_idx]);
-
-      // count how many we used
-      for (i = 0; i < p->num_probes; i++) {
-        if (p->probes[i].s != INVALID_SOCKET)
-          current_pfd_idx++;
-      }
+      FWD_ProcessProbes(p);
 
       // Check completion again in case we got last packet or timed out
       FWD_CheckProbeCompletion(p);
       continue; // Skip normal processing for this peer
     }
 
-    if (pfds[current_pfd_idx].revents & POLLIN) {
+    if (p->revents & POLLIN) {
       // yeah, we have packet, read it then
       for (;;) {
         if (!NET_GetPacket(p->s, &net_message))
@@ -620,8 +653,6 @@ retry:
       } // for (;;)
     } // if(POLLIN)
 
-    current_pfd_idx++;
-
     if (p->ps == ps_challenge || p->ps == ps_connecting) {
       // send challenge time to time
       if (time(NULL) - p->connect > 2) {
@@ -632,6 +663,7 @@ retry:
     }
   } // for (p = peers; p; p = p->next)
 
+  Sys_free(owners);
   Sys_free(pfds);
 }
 

--- a/src/peer.c
+++ b/src/peer.c
@@ -32,8 +32,23 @@ typedef struct {
 	probe_t *probe; // NULL when the entry is the peer's main socket
 } pfd_owner_t;
 
+// Both are complete connectionless packets, including the 0xffffffff
+// out-of-band header the receiver checks before parsing the command.
 static const char probe_payload_qw[] = {0xff, 0xff, 0xff, 0xff, 'p', 'i', 'n', 'g', '\n'};
-static const char probe_payload_gen[] = {A2A_PING, 0};
+static const char probe_payload_gen[] = {0xff, 0xff, 0xff, 0xff, A2A_PING, 0};
+
+// Probes must retransmit exactly what they first sent, so both send sites take
+// the payload from here.
+static void FWD_ProbePayload(const peer_t *p, const void **payload, int *payload_len)
+{
+	if (p->proto == pr_qw) {
+		*payload = probe_payload_qw;
+		*payload_len = sizeof(probe_payload_qw);
+	} else {
+		*payload = probe_payload_gen;
+		*payload_len = sizeof(probe_payload_gen);
+	}
+}
 
 cvar_t *sv_pathprobe_enable;
 cvar_t *sv_pathprobe_count;
@@ -254,16 +269,21 @@ void FWD_PeerStartProbing(peer_t *p) {
   }
   p->probe_start_time = Sys_DoubleTime();
 
-  if (p->proto == pr_qw) {
-    payload = probe_payload_qw;
-    payload_len = sizeof(probe_payload_qw);
-  } else {
-    payload = probe_payload_gen;
-    payload_len = sizeof(probe_payload_gen);
-  }
+  FWD_ProbePayload(p, &payload, &payload_len);
 
   // Use existing socket as first probe
   if (p->s != INVALID_SOCKET) {
+    // Discard whatever is already queued on it. On a reconnect this socket has
+    // been carrying game traffic, and FWD_ProcessProbes() accepts any packet
+    // from p->to as a reply: a leftover frame would score as a near-zero RTT
+    // that no real sample can beat, so probes[0] would always "win" and the
+    // peer would silently keep the port it already had.
+    // NOTE: recvfrom() directly, not NET_GetPacket() - our caller
+    // (SVC_DirectConnect) is still using net_message/net_from.
+    char drain[MSG_BUF_SIZE];
+    while (recvfrom(p->s, drain, sizeof(drain), 0, NULL, NULL) >= 0)
+      ;
+
     p->probes[0].s = p->s;
     p->probes[0].send_time = Sys_DoubleTime();
     p->probes[0].rtt = -1;
@@ -387,13 +407,7 @@ static void FWD_ProcessProbes(peer_t *p) {
   const void *payload;
   int payload_len;
 
-  if (p->proto == pr_qw) {
-    payload = QW_PROBE_PAYLOAD;
-    payload_len = sizeof(QW_PROBE_PAYLOAD) - 1;
-  } else {
-    payload = GEN_PROBE_PAYLOAD;
-    payload_len = sizeof(GEN_PROBE_PAYLOAD) - 1;
-  }
+  FWD_ProbePayload(p, &payload, &payload_len);
 
   for (i = 0; i < p->num_probes; i++) {
     if (p->probes[i].s != INVALID_SOCKET) {
@@ -434,7 +448,9 @@ static void FWD_network_update(void) {
   int max_fds = 2; // net + stdin
   int retval;
   int net_idx = -1;
+#ifndef _WIN32
   int stdin_idx = -1;
+#endif
   peer_t *p;
   int i;
 
@@ -527,11 +543,21 @@ retry:
 
   // read console input.
   // NOTE: we do not do that if we are in DLL mode...
-  if (stdin_idx != -1 && (pfds[stdin_idx].revents & POLLIN)) {
+  {
     fd_set rfds;
     FD_ZERO(&rfds);
-    FD_SET(STDIN, &rfds);
+#ifdef _WIN32
+    // STDIN gets no pollfd entry on Windows: WSAPoll() handles sockets only.
+    // The Windows half of Sys_ReadSTDIN() polls the console with
+    // _kbhit()/_getch() and ignores the fd_set, so it has to be called every
+    // iteration or console commands never get read.
     Sys_ReadSTDIN(&ps, rfds);
+#else
+    if (stdin_idx != -1 && (pfds[stdin_idx].revents & POLLIN)) {
+      FD_SET(STDIN, &rfds);
+      Sys_ReadSTDIN(&ps, rfds);
+    }
+#endif
   }
 
   // if we have input packet on main server/proxy socket, then read it

--- a/src/peer.c
+++ b/src/peer.c
@@ -7,6 +7,30 @@
 peer_t *peers = NULL;
 static int userid = 0;
 
+static int GetGlobalProbeSocketsOpen(void) {
+	int count = 0;
+	peer_t *p;
+	for (p = peers; p; p = p->next) {
+		if (p->ps == ps_pingprobe) {
+			int i;
+			for (i = 0; i < p->num_probes; i++) {
+				if (p->probes[i].s != INVALID_SOCKET)
+					count++;
+			}
+		}
+	}
+	return count;
+}
+
+#define MAX_TOTAL_PROBE_SOCKETS 64
+
+static const char probe_payload_qw[] = {0xff, 0xff, 0xff, 0xff, 'p', 'i', 'n', 'g', '\n'};
+static const char probe_payload_gen[] = {A2A_PING, 0};
+
+cvar_t *sv_pathprobe_enable;
+cvar_t *sv_pathprobe_count;
+cvar_t *sv_pathprobe_delay;
+
 peer_t	*FWD_peer_by_addr(struct sockaddr_in *from)
 {
 	peer_t *p;
@@ -69,7 +93,7 @@ peer_t	*FWD_peer_new(const char *remote_host, int remote_port, struct sockaddr_i
 	p->s		= ( new_peer ) ? s : p->s; // reuse socket in case of reusing
 	p->from		= *from;
 	p->to		= to;
-	p->ps		= ( !new_peer && proto == pr_q3 ) ? p->ps : ps_challenge; // do not reset state for q3 in case of peer reusing
+	p->ps		= ( !new_peer && (proto == pr_q3 || p->ps == ps_pingprobe) ) ? p->ps : ps_challenge; // do not reset state for q3 or ongoing probes in case of peer reusing
 	p->qport	= qport;
 	p->proto	= proto;
 	strlcpy(p->userinfo, userinfo, sizeof(p->userinfo));
@@ -93,6 +117,8 @@ peer_t	*FWD_peer_new(const char *remote_host, int remote_port, struct sockaddr_i
 // free peer data, perform unlink if requested
 static void FWD_peer_free(peer_t *peer, qbool unlink)
 {
+	int i;
+
 	if (!peer)
 		return;
 
@@ -122,9 +148,20 @@ static void FWD_peer_free(peer_t *peer, qbool unlink)
 		}
 	}
 
+	// free probes if any
+	for (i = 0; i < peer->num_probes; i++) {
+		if (peer->probes[i].s != INVALID_SOCKET && peer->probes[i].s != peer->s) {
+			closesocket(peer->probes[i].s);
+			peer->probes[i].s = INVALID_SOCKET;
+		}
+	}
+
 	// free all data related to peer
-	if (peer->s) // there should be no zero socket, it's stdin
+	if (peer->s) { // there should be no zero socket, it's stdin
 		closesocket(peer->s);
+		peer->s = INVALID_SOCKET;
+	}
+
 	Sys_free(peer);
 }
 
@@ -181,187 +218,421 @@ static void FWD_check_drop(void)
 	}
 }
 
-static void FWD_network_update(void)
-{
-	fd_set rfds;
-	struct timeval tv;
-	int retval;
-	int i1;
-	peer_t *p;
+// Start probing for the best source port
+void FWD_PeerStartProbing(peer_t *p) {
+  int count = sv_pathprobe_count->integer;
+  int i;
+  const void *payload;
+  int payload_len;
 
-	FD_ZERO(&rfds);
+  if (count < 1)
+    count = 1;
+  if (count > MAX_PING_PROBES)
+    count = MAX_PING_PROBES;
 
-	// select on main server socket
-	FD_SET(net_socket, &rfds);
-	i1 = net_socket + 1;
+  // Close any existing probe sockets to prevent leaks on reuse
+  for (i = 0; i < p->num_probes; i++) {
+    if (p->probes[i].s != INVALID_SOCKET && p->probes[i].s > 0 &&
+        p->probes[i].s != p->s) {
+      closesocket(p->probes[i].s);
+    }
+  }
 
-	for (p = peers; p; p = p->next)
-	{
-		// select on peers sockets
-		FD_SET(p->s, &rfds);
-		if (p->s >= i1)
-			i1 = p->s + 1;
-	}
+  p->ps = ps_pingprobe;
+  p->num_probes = 0;
+  memset(p->probes, 0, sizeof(p->probes));
+  for (i = 0; i < MAX_PING_PROBES; i++) {
+    p->probes[i].s = INVALID_SOCKET;
+  }
+  p->probe_start_time = Sys_DoubleTime();
+
+  if (p->proto == pr_qw) {
+    payload = probe_payload_qw;
+    payload_len = sizeof(probe_payload_qw);
+  } else {
+    payload = probe_payload_gen;
+    payload_len = sizeof(probe_payload_gen);
+  }
+
+  // Use existing socket as first probe
+  if (p->s != INVALID_SOCKET) {
+    p->probes[0].s = p->s;
+    p->probes[0].send_time = Sys_DoubleTime();
+    p->probes[0].rtt = -1;
+    p->probes[0].samples_sent = 1;
+    p->num_probes++;
+    NET_SendPacket(p->s, payload_len, payload, &p->to);
+  }
+
+  // Create additional sockets
+  for (i = p->num_probes; i < count; i++) {
+    if (GetGlobalProbeSocketsOpen() >= MAX_TOTAL_PROBE_SOCKETS) {
+      Sys_DPrintf(
+          "Global probe socket limit reached (%d), skipping probe socket\n",
+          MAX_TOTAL_PROBE_SOCKETS);
+      break;
+    }
+
+    int s = NET_UDP_OpenSocket(NULL, 0, false);
+    if (s != INVALID_SOCKET) {
+      p->probes[p->num_probes].s = s;
+      p->probes[p->num_probes].send_time = Sys_DoubleTime();
+      p->probes[p->num_probes].rtt = -1;
+      p->probes[p->num_probes].samples_sent = 1;
+      p->num_probes++;
+      NET_SendPacket(s, payload_len, payload, &p->to);
+    }
+  }
+
+  Sys_DPrintf("Started probing %d ports for peer %s\n", p->num_probes, p->name);
+}
+
+// Check if probing is done or timed out
+static void FWD_CheckProbeCompletion(peer_t *p) {
+  int i;
+  int best_idx = -1;
+  double best_rtt = 99999.0;
+  double timeout = sv_pathprobe_delay->value / 1000.0;
+  qbool all_finished = true;
+  int fully_sampled = 0;
+
+  if (timeout <= 0.0)
+    timeout = 1.0;
+  if (timeout > 10.0)
+    timeout = 10.0;
+
+  // Check if all probes are finished
+  for (i = 0; i < p->num_probes; i++) {
+    if (p->probes[i].samples_received >= 2)
+      fully_sampled++;
+
+    if (p->probes[i].samples_received < PROBE_SAMPLES_COUNT) {
+      all_finished = false;
+    }
+  }
+
+  // Wait for at least 2 samples from everyone to filter jitter, unless timed
+  // out
+  if (fully_sampled == p->num_probes)
+    goto select_best;
+
+  // Only proceed if we timed out or all probes finished
+  if (!all_finished && Sys_DoubleTime() - p->probe_start_time <= timeout)
+    return;
+
+select_best:
+  // Find best RTT
+  for (i = 0; i < p->num_probes; i++) {
+    if (p->probes[i].rtt > 0 && p->probes[i].rtt < best_rtt) {
+      best_rtt = p->probes[i].rtt;
+      best_idx = i;
+    }
+  }
+
+  if (best_idx != -1) {
+    Sys_DPrintf("Probe finished in %.2f ms. Best RTT: %.2f ms (idx %d)\n",
+                (Sys_DoubleTime() - p->probe_start_time) * 1000.0,
+                best_rtt * 1000.0, best_idx);
+    p->s = p->probes[best_idx].s;
+
+    // Notify client about the best ping found
+    if (p->proto == pr_qw) {
+      Netchan_OutOfBandPrint(net_socket, &p->from,
+                             "%c[qwfwd] Best RTT: %.2f ms\n", A2C_PRINT,
+                             best_rtt * 1000.0);
+    } else {
+      Netchan_OutOfBandPrint(net_socket, &p->from,
+                             "print\n[qwfwd] Best RTT: %.2f ms\n",
+                             best_rtt * 1000.0);
+    }
+
+  } else {
+    Sys_DPrintf("Probe finished. No reply, using default.\n");
+    p->s = p->probes[0].s; // Fallback to first
+  }
+
+  // Close other sockets
+  for (i = 0; i < p->num_probes; i++) {
+    if (p->probes[i].s != p->s && p->probes[i].s != INVALID_SOCKET) {
+      closesocket(p->probes[i].s);
+      p->probes[i].s = INVALID_SOCKET;
+    }
+  }
+
+  // Send connection packet to client now that we are ready
+  if (p->proto == pr_qw) {
+    Netchan_OutOfBandPrint(net_socket, &p->from, "%c", S2C_CONNECTION);
+  } else {
+    Netchan_OutOfBandPrint(net_socket, &p->from, "connectResponse");
+  }
+
+  p->ps = ps_connecting;
+  p->connect = 0;
+}
+
+// Process incoming packets on probe sockets
+static void FWD_ProcessProbes(peer_t *p, net_pollfd_t *pfds) {
+  int i;
+  int current_probe_pfd = 0;
+  const void *payload;
+  int payload_len;
+
+  if (p->proto == pr_qw) {
+    payload = QW_PROBE_PAYLOAD;
+    payload_len = sizeof(QW_PROBE_PAYLOAD) - 1;
+  } else {
+    payload = GEN_PROBE_PAYLOAD;
+    payload_len = sizeof(GEN_PROBE_PAYLOAD) - 1;
+  }
+
+  for (i = 0; i < p->num_probes; i++) {
+    if (p->probes[i].s != INVALID_SOCKET) {
+      if (pfds[current_probe_pfd].revents & POLLIN) {
+        if (NET_GetPacket(p->probes[i].s, &net_message)) {
+          if (NET_CompareAddress(&p->to, &net_from)) {
+            // Any reply from the server on the probe socket is enough to
+            // measure RTT
+            double rtt = Sys_DoubleTime() - p->probes[i].send_time;
+
+            p->probes[i].samples_received++;
+
+            if (p->probes[i].rtt == -1 || rtt < p->probes[i].rtt) {
+              p->probes[i].rtt = rtt;
+              Sys_DPrintf(
+                  "Pathprobe reply on socket %d, sample %d, RTT %.2f ms\n",
+                  p->probes[i].s, p->probes[i].samples_received,
+                  p->probes[i].rtt * 1000.0);
+            }
+
+            // Send next sample if needed
+            if (p->probes[i].samples_sent < PROBE_SAMPLES_COUNT) {
+              p->probes[i].samples_sent++;
+              p->probes[i].send_time = Sys_DoubleTime();
+              NET_SendPacket(p->probes[i].s, payload_len, payload, &p->to);
+            }
+          }
+        }
+      }
+      current_probe_pfd++;
+    }
+  }
+}
+
+static void FWD_network_update(void) {
+  net_pollfd_t *pfds = NULL;
+  int nfds = 0;
+  int max_fds = 2; // net + stdin
+  int retval;
+  int net_idx = -1;
+  int stdin_idx = -1;
+  peer_t *p;
+  int i;
+  int current_pfd_idx;
+
+  // Calculate max FDs needed
+  for (p = peers; p; p = p->next) {
+    if (p->ps == ps_pingprobe) {
+      max_fds += p->num_probes;
+    } else {
+      max_fds++;
+    }
+  }
+
+  pfds = Sys_malloc(sizeof(net_pollfd_t) * max_fds);
+
+  // select on main server socket
+  pfds[nfds].fd = net_socket;
+  pfds[nfds].events = POLLIN;
+  pfds[nfds].revents = 0;
+  net_idx = nfds++;
+
+  for (p = peers; p; p = p->next) {
+    // select on peers sockets
+    if (p->ps == ps_pingprobe) {
+      for (i = 0; i < p->num_probes; i++) {
+        if (p->probes[i].s != INVALID_SOCKET) {
+          pfds[nfds].fd = p->probes[i].s;
+          pfds[nfds].events = POLLIN;
+          pfds[nfds].revents = 0;
+          nfds++;
+        }
+      }
+    } else {
+      pfds[nfds].fd = p->s;
+      pfds[nfds].events = POLLIN;
+      pfds[nfds].revents = 0;
+      nfds++;
+    }
+  }
 
 // if not DLL - read stdin
 #ifndef APP_DLL
-	#ifndef _WIN32
-	// try read stdin only if connected to a terminal.
-	if (isatty(STDIN) && isatty(STDOUT))
-	{
-		FD_SET(STDIN, &rfds);
-		if (STDIN >= i1)
-			i1 = STDIN + 1;
-	}
-	#endif // _WIN32
+#ifndef _WIN32
+  // try read stdin only if connected to a terminal.
+  if (isatty(STDIN) && isatty(STDOUT)) {
+    pfds[nfds].fd = STDIN;
+    pfds[nfds].events = POLLIN;
+    pfds[nfds].revents = 0;
+    stdin_idx = nfds++;
+  }
+#endif // _WIN32
 #endif
 
-	/* Sleep for some time, wake up immidiately if there input packet. */
-	tv.tv_sec = 0;
-	tv.tv_usec = 100000; // 100 ms
-
 retry:
-	retval = select(i1, &rfds, (fd_set *)0, (fd_set *)0, &tv);
-	if (retval < 0)
-	{
-		if (errno == EINTR)
-		{
-			goto retry;
-		}
-		perror("select");
-		return;
-	}
+  retval = qpoll(pfds, nfds, 100);
+  if (retval < 0) {
+    if (errno == EINTR) {
+      goto retry;
+    }
+    perror("poll");
+    Sys_free(pfds);
+    return;
+  }
 
-	// read console input.
-	// NOTE: we do not do that if we are in DLL mode...
-	Sys_ReadSTDIN(&ps, rfds);
+  // read console input.
+  // NOTE: we do not do that if we are in DLL mode...
+  if (stdin_idx != -1 && (pfds[stdin_idx].revents & POLLIN)) {
+    fd_set rfds;
+    FD_ZERO(&rfds);
+    FD_SET(STDIN, &rfds);
+    Sys_ReadSTDIN(&ps, rfds);
+  }
 
-	if (retval <= 0)
-		return;
+  // if we have input packet on main server/proxy socket, then read it
+  if (net_idx != -1 && (pfds[net_idx].revents & POLLIN)) {
+    qbool connectionless;
+    int cnt;
 
-	// if we have input packet on main server/proxy socket, then read it
-	if(FD_ISSET(net_socket, &rfds))
-	{
-		qbool connectionless;
-		int cnt;
+    // read it
+    for (;;) {
+      if (!NET_GetPacket(net_socket, &net_message))
+        break;
 
-		// read it
-		for(;;)
-		{
-			if (!NET_GetPacket(net_socket, &net_message))
-				break;
+      // check for bans.
+      if (SV_IsBanned(&net_from))
+        continue;
 
-			// check for bans.
-			if (SV_IsBanned(&net_from))
-				continue;
+      if (net_message.cursize == 1 && net_message.data[0] == A2A_ACK) {
+        QRY_SV_PingReply();
 
-			if (net_message.cursize == 1 && net_message.data[0] == A2A_ACK)
-			{
-				QRY_SV_PingReply();
+        continue;
+      }
 
-				continue;
-			}
+      MSG_BeginReading();
+      connectionless = (MSG_ReadLong() == -1);
 
-			MSG_BeginReading();
-			connectionless = (MSG_ReadLong() == -1);
+      if (connectionless) {
+        if (MSG_BadRead())
+          continue;
 
-			if (connectionless)
-			{
-				if (MSG_BadRead())
-					continue;
+        if (!SV_ConnectionlessPacket())
+          continue; // seems we do not need forward it
+      }
 
-				if (!SV_ConnectionlessPacket())
-					continue; // seems we do not need forward it
-			}
+      // search in peers
+      for (p = peers; p; p = p->next) {
+        // we have this peer already, so forward/send packet to remote server
+        if (NET_CompareAddress(&p->from, &net_from))
+          break;
+      }
 
-			// search in peers
-			for (p = peers; p; p = p->next)
-			{
-				// we have this peer already, so forward/send packet to remote server
-				if (NET_CompareAddress(&p->from, &net_from))
-					break;
-			}
+      // peer was not found
+      if (!p)
+        continue;
 
-			// peer was not found
-			if (!p)
-				continue;
+      // forward data to the server/proxy
+      if (p->ps >= ps_connected) {
+        cnt = 1; // one packet by default
 
-			// forward data to the server/proxy
-			if (p->ps >= ps_connected)
-			{
-				cnt = 1; // one packet by default
+        // check for "drop" aka client disconnect,
+        // first 10 bytes for NON connectionless packet is netchan related shit
+        // in QW
+        if (p->proto == pr_qw && !connectionless && net_message.cursize > 10 &&
+            net_message.data[10] == clc_stringcmd) {
+          if (!strcmp((char *)net_message.data + 10 + 1, "drop")) {
+            //						Sys_Printf("peer drop
+            // detected\n");
+            p->ps = ps_drop; // drop peer ASAP
+            cnt = 3;         // send few packets due to possibile packet lost
+          }
+        }
 
-				// check for "drop" aka client disconnect,
-				// first 10 bytes for NON connectionless packet is netchan related shit in QW
-				if (p->proto == pr_qw && !connectionless && net_message.cursize > 10 && net_message.data[10] == clc_stringcmd)
-				{
-					if (!strcmp((char*)net_message.data + 10 + 1, "drop"))
-					{
-//						Sys_Printf("peer drop detected\n");
-						p->ps = ps_drop; // drop peer ASAP
-						cnt = 3; // send few packets due to possibile packet lost
-					}
-				}
+        for (; cnt > 0; cnt--)
+          NET_SendPacket(p->s, net_message.cursize, net_message.data, &p->to);
+      }
 
-				for ( ; cnt > 0; cnt--)
-					NET_SendPacket(p->s, net_message.cursize, net_message.data, &p->to);
-			}
+      time(&p->last);
+    }
+  }
 
-			time(&p->last);
-		}
-	}
+  // now lets check peers sockets, perhaps we have input packets too
+  current_pfd_idx = 1; // skip net_socket
+  for (p = peers; p; p = p->next) {
+    if (p->ps == ps_pingprobe) {
+      FWD_ProcessProbes(p, &pfds[current_pfd_idx]);
 
-	// now lets check peers sockets, perhaps we have input packets too
-	for (p = peers; p; p = p->next)
-	{
-		if(FD_ISSET(p->s, &rfds))
-		{
-			// yeah, we have packet, read it then
-			for (;;)
-			{
-				if (!NET_GetPacket(p->s, &net_message))
-					break;
+      // count how many we used
+      for (i = 0; i < p->num_probes; i++) {
+        if (p->probes[i].s != INVALID_SOCKET)
+          current_pfd_idx++;
+      }
 
-				// check for bans.
-				if (SV_IsBanned(&net_from))
-					continue;
+      // Check completion again in case we got last packet or timed out
+      FWD_CheckProbeCompletion(p);
+      continue; // Skip normal processing for this peer
+    }
 
-				// we should check is this packet from remote server, this may be some evil packet from haxors...
-				if (!NET_CompareAddress(&p->to, &net_from))
-					continue;
+    if (pfds[current_pfd_idx].revents & POLLIN) {
+      // yeah, we have packet, read it then
+      for (;;) {
+        if (!NET_GetPacket(p->s, &net_message))
+          break;
 
-				MSG_BeginReading();
-				if (MSG_ReadLong() == -1)
-				{
-					if (MSG_BadRead())
-						continue;
+        // check for bans.
+        if (SV_IsBanned(&net_from))
+          continue;
 
-					if (!CL_ConnectionlessPacket(p))
-						continue; // seems we do not need forward it
+        // we should check is this packet from remote server, this may be some
+        // evil packet from haxors...
+        if (!NET_CompareAddress(&p->to, &net_from))
+          continue;
 
-					NET_SendPacket(net_socket, net_message.cursize, net_message.data, &p->from);
-					continue;
-				}
+        MSG_BeginReading();
+        if (MSG_ReadLong() == -1) {
+          if (MSG_BadRead())
+            continue;
 
-				if (p->ps >= ps_connected)
-					NET_SendPacket(net_socket, net_message.cursize, net_message.data, &p->from);
+          if (!CL_ConnectionlessPacket(p))
+            continue; // seems we do not need forward it
 
-// qqshka: commented out
-//				time(&p->last);
+          NET_SendPacket(net_socket, net_message.cursize, net_message.data,
+                         &p->from);
+          continue;
+        }
 
-			} // for (;;)
-		} // if(FD_ISSET(p->s, &rfds))
+        if (p->ps >= ps_connected)
+          NET_SendPacket(net_socket, net_message.cursize, net_message.data,
+                         &p->from);
 
-		if (p->ps == ps_challenge)
-		{
-			// send challenge time to time
-			if (time(NULL) - p->connect > 2)
-			{
-				p->connect = time(NULL);
-				Netchan_OutOfBandPrint(p->s, &p->to, "getchallenge%s", p->proto == pr_qw ? "\n" : "");
-			}
-		}
-	} // for (p = peers; p; p = p->next)
+        // qqshka: commented out
+        //				time(&p->last);
+
+      } // for (;;)
+    } // if(POLLIN)
+
+    current_pfd_idx++;
+
+    if (p->ps == ps_challenge || p->ps == ps_connecting) {
+      // send challenge time to time
+      if (time(NULL) - p->connect > 2) {
+        p->connect = time(NULL);
+        Netchan_OutOfBandPrint(p->s, &p->to, "getchallenge%s",
+                               p->proto == pr_qw ? "\n" : "");
+      }
+    }
+  } // for (p = peers; p; p = p->next)
+
+  Sys_free(pfds);
 }
 
 int FWD_peers_count(void)

--- a/src/qwfwd.h
+++ b/src/qwfwd.h
@@ -163,6 +163,7 @@ typedef struct {
   double rtt;
   int samples_sent;
   int samples_received;
+  short revents;				// poll() result for this probe socket, see FWD_network_update()
 } probe_t;
 
 
@@ -183,6 +184,7 @@ typedef struct peer
 	int s;							// socket, used for connection to remote host
 	peer_state_t ps;				// peer state
 	protocol_t	proto;				// which protocol we use
+	short revents;					// poll() result for 's', see FWD_network_update()
 	struct peer *next;				// next peer in linked list
 
 	// pingprobe

--- a/src/qwfwd.h
+++ b/src/qwfwd.h
@@ -69,6 +69,7 @@
 #include <netdb.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
+#include <poll.h>
 #include <unistd.h>
 #include <syslog.h>
 #include <pthread.h>
@@ -77,6 +78,14 @@
 #define closesocket		close
 #define qerrno			errno
 
+#endif
+
+#ifdef _WIN32
+#define qpoll WSAPoll
+typedef WSAPOLLFD net_pollfd_t;
+#else
+#define qpoll poll
+typedef struct pollfd net_pollfd_t;
 #endif
 
 #ifndef INVALID_SOCKET
@@ -136,9 +145,25 @@ typedef enum
 typedef enum
 {
 	ps_drop,		// we should drop this peer soon
+	ps_pingprobe,	// probing source ports
 	ps_challenge,	// peer getting a challenge
+	ps_connecting,	// challenge done, waiting for connection ack
 	ps_connected	// peer fully connected
 } peer_state_t;
+
+
+#define MAX_PING_PROBES 10
+#define PROBE_SAMPLES_COUNT 3
+#define QW_PROBE_PAYLOAD "\xff\xff\xff\xffping\n"
+#define GEN_PROBE_PAYLOAD "\x6B" // A2A_PING
+
+typedef struct {
+  int s;
+  double send_time;
+  double rtt;
+  int samples_sent;
+  int samples_received;
+} probe_t;
 
 
 typedef struct peer
@@ -159,6 +184,11 @@ typedef struct peer
 	peer_state_t ps;				// peer state
 	protocol_t	proto;				// which protocol we use
 	struct peer *next;				// next peer in linked list
+
+	// pingprobe
+	probe_t probes[MAX_PING_PROBES];
+	int num_probes;
+	double probe_start_time;
 } peer_t;
 
 // used for passing params for thread
@@ -225,6 +255,7 @@ extern proxy_static_t ps;
 
 extern cvar_t *developer, *maxclients, *hostname;
 extern cvar_t *hostport, *countrycode, *city, *coords;
+extern cvar_t *sv_pathprobe_enable, *sv_pathprobe_count, *sv_pathprobe_delay;
 
 //
 // token.c
@@ -265,6 +296,7 @@ extern	peer_t		*peers;
 peer_t		*FWD_peer_by_addr(struct sockaddr_in *from);
 peer_t		*FWD_peer_new(const char *remote_host, int remote_port, struct sockaddr_in *from, const char *userinfo, int qport, protocol_t proto, qbool link);
 void		FWD_update_peers(void);
+void		FWD_PeerStartProbing(peer_t *p);
 
 int			FWD_peers_count(void);
 

--- a/src/qwfwd.h
+++ b/src/qwfwd.h
@@ -154,8 +154,6 @@ typedef enum
 
 #define MAX_PING_PROBES 10
 #define PROBE_SAMPLES_COUNT 3
-#define QW_PROBE_PAYLOAD "\xff\xff\xff\xffping\n"
-#define GEN_PROBE_PAYLOAD "\x6B" // A2A_PING
 
 typedef struct {
   int s;

--- a/src/svc.c
+++ b/src/svc.c
@@ -187,7 +187,7 @@ static void SVC_DirectConnect (void)
 
 	char userinfo[MAX_INFO_STRING], prx[MAX_INFO_KEY * 4 /* we allow huge size for prx */], *at;
 	peer_t *p = NULL;
-	int qport, port, challenge;
+	int qport, port;
 	protocol_t proto;
 
 	if ( i >= MAX_CHALLENGES )
@@ -198,7 +198,6 @@ static void SVC_DirectConnect (void)
 	}
 
 	proto = challenges[i].proto;
-	challenge = challenges[i].challenge;
 
 	// different for qw and q3
 	if ( proto == pr_qw )
@@ -294,7 +293,36 @@ static void SVC_DirectConnect (void)
 	// this was new peer, lets register it then
 	if ((p = FWD_peer_new(prx, port, &net_from, userinfo, qport, proto, true)))
 	{
+		qbool do_probe = false;
+		char val[64];
+
 		Sys_DPrintf("peer %s:%d added or reused\n", inet_ntoa(net_from.sin_addr), (int)ntohs(net_from.sin_port));
+
+		// Check if client wants to override pingprobe setting
+		Info_ValueForKey(userinfo, "pathprobe", val, sizeof(val));
+		if (val[0]) {
+			do_probe = atoi(val);
+		}
+
+		// Check if feature is globally disabled
+		if (!sv_pathprobe_enable->integer) {
+			do_probe = false;
+		}
+
+		// Disable probing for non-QW protocols (Q3 does not support this probe method)
+		if (proto != pr_qw) {
+			do_probe = false;
+		}
+
+		if (do_probe) {
+			if (p->ps == ps_challenge) {
+				FWD_PeerStartProbing(p);
+			} else if (p->ps == ps_pingprobe) {
+				Sys_DPrintf("Peer already probing, ignoring duplicate connect\n");
+			} else {
+				Sys_DPrintf("Peer reused, skipping probe (state %d)\n", p->ps);
+			}
+		}
 	}
 	else
 	{
@@ -304,13 +332,16 @@ static void SVC_DirectConnect (void)
 
 	if ( proto == pr_qw )
 	{
-		Netchan_OutOfBandPrint(net_from_socket, &net_from, "%c", S2C_CONNECTION);
+		if (p->ps != ps_pingprobe)
+			Netchan_OutOfBandPrint(net_from_socket, &net_from, "%c", S2C_CONNECTION);
 	}
 	else
 	{
 		if ( p->ps == ps_connected )
 		{
-			if ( p->challenge == challenge )
+			int client_challenge = challenges[i].challenge;
+
+			if ( p->challenge == client_challenge )
 			{
 				// ok, we are really really ready to transfer data
 				Netchan_OutOfBandPrint(net_from_socket, &net_from, "connectResponse");

--- a/src/svc.c
+++ b/src/svc.c
@@ -293,19 +293,17 @@ static void SVC_DirectConnect (void)
 	// this was new peer, lets register it then
 	if ((p = FWD_peer_new(prx, port, &net_from, userinfo, qport, proto, true)))
 	{
-		qbool do_probe = false;
+		// The cvar is the server-wide default; a client may opt out per
+		// connection with a "pathprobe" userinfo key. It stays a kill switch:
+		// when disabled no client can turn probing back on.
+		qbool do_probe = !!sv_pathprobe_enable->integer;
 		char val[64];
 
 		Sys_DPrintf("peer %s:%d added or reused\n", inet_ntoa(net_from.sin_addr), (int)ntohs(net_from.sin_port));
 
-		// Check if client wants to override pingprobe setting
+		// Check if client wants to override pathprobe setting
 		Info_ValueForKey(userinfo, "pathprobe", val, sizeof(val));
-		if (val[0]) {
-			do_probe = atoi(val);
-		}
-
-		// Check if feature is globally disabled
-		if (!sv_pathprobe_enable->integer) {
+		if (val[0] && !atoi(val)) {
 			do_probe = false;
 		}
 


### PR DESCRIPTION
AI-coded pathprober, it has been running on a number of servers for a week and seems to work great.
to enable it use setinfo pathprobe 1 in quake.

For obvious reasons someone has to look into it, if its wort it.

New Server Variables (qwfwd.cfg)

These variables control the PathProbe feature on the proxy side. They are available immediately after updating.

sv_pathprobe_enable (Default: 1)

Description: The master switch for the feature.
1 = Enabled (Clients can request PathProbe).
0 = Disabled (PathProbe requests are ignored, standard behavior applies).
sv_pathprobe_count (Default: 64)

Description: The number of source ports (sockets) to "race" simultaneously when a client connects.
Impact: Higher values increase the chance of finding a better route but use more file descriptors. 64 is the recommended sweet spot for covering ECMP hashes.
sv_pathprobe_delay (Default: 1000)

Description: The maximum time (in milliseconds) the proxy will wait for probe results.
Note: The feature usually finishes in <50ms (1 RTT + processing). This is just a safety timeout to prevent hanging if the network is extremely lossy.