### PR TITLE
Add configurable default server and multi-port routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,21 @@ You can find the prebuilt binaries on [this download page][qwfwd-builds].
 
 None at the moment.
 
+## Default server
+
+Set `default_server` to let clients connect directly to QWFWD without configuring
+the `prx` userinfo key:
+
+```
+set net_ip 188.120.226.217
+set net_port 27500
+set default_server qwtf.net:27500
+```
+
+QWFWD establishes the connection to `default_server` through the proxy. When
+`default_server` is empty, clients without a `prx` key continue to receive the
+existing `prx userinfo key is not set` error.
+
 ## Building binaries
 
 ### Build from source with CMake

--- a/README.md
+++ b/README.md
@@ -18,20 +18,40 @@ You can find the prebuilt binaries on [this download page][qwfwd-builds].
 
 None at the moment.
 
-## Default server
+## Default server and multiple listening ports
 
 Set `default_server` to let clients connect directly to QWFWD without configuring
-the `prx` userinfo key:
+the `prx` userinfo key. When the value does not include a port, QWFWD preserves
+the port on which the client connected:
 
-```
+```cfg
 set net_ip 188.120.226.217
-set net_port 27500
-set default_server qwtf.net:27500
+set net_ports "27500 27501"
+set default_server qwtf.net
 ```
 
-QWFWD establishes the connection to `default_server` through the proxy. When
-`default_server` is empty, clients without a `prx` key continue to receive the
-existing `prx userinfo key is not set` error.
+This configuration creates the following routes through QWFWD:
+
+```text
+188.120.226.217:27500 -> qwtf.net:27500
+188.120.226.217:27501 -> qwtf.net:27501
+```
+
+Use `default_server_map` to override individual ports:
+
+```cfg
+set default_server_map "27501=qwtf.net:27502"
+```
+
+The override routes `188.120.226.217:27501` to `qwtf.net:27502`. Multiple
+overrides can be separated by spaces. `net_ports` also accepts comma-separated
+ports and ranges such as `27500-27510`.
+
+The existing `net_port` setting remains supported when `net_ports` is empty.
+An explicit port in `default_server`, for example `qwtf.net:27500`, is used for
+every listening port without a map override. An explicit client `prx` value
+continues to take precedence. When neither `default_server` nor a matching map
+entry is configured, the existing `prx userinfo key is not set` error is returned.
 
 ## Building binaries
 

--- a/resources/example-configs/qwfwd.cfg
+++ b/resources/example-configs/qwfwd.cfg
@@ -15,12 +15,19 @@ set hostname QWFWD
 // UDP port on which QWFWD will listen for client, default port is 30000
 // set net_port 30000
 
+// Optional list of UDP ports or ranges. When set, this replaces net_port.
+// set net_ports "27500 27501 27600-27610"
+
 // IP address on which QWFWD will listen for client, default is all host IP addresses
 // set net_ip X.X.X.X
 
 // Server used when a client connects directly without a prx userinfo key.
+// Without an explicit destination port, the incoming listening port is preserved.
 // The connection is still proxied through QWFWD.
-// set default_server qwtf.net:27500
+// set default_server qwtf.net
+
+// Optional per-listening-port destination overrides, separated by spaces.
+// set default_server_map "27501=qwtf.net:27502"
 
 // Developer mode, default is 0 (0=disabled, 1=enabled)
 // set developer 0

--- a/resources/example-configs/qwfwd.cfg
+++ b/resources/example-configs/qwfwd.cfg
@@ -18,6 +18,10 @@ set hostname QWFWD
 // IP address on which QWFWD will listen for client, default is all host IP addresses
 // set net_ip X.X.X.X
 
+// Server used when a client connects directly without a prx userinfo key.
+// The connection is still proxied through QWFWD.
+// set default_server qwtf.net:27500
+
 // Developer mode, default is 0 (0=disabled, 1=enabled)
 // set developer 0
 

--- a/src/main.c
+++ b/src/main.c
@@ -19,6 +19,7 @@ cvar_t *hostport;
 cvar_t *countrycode;
 cvar_t *city;
 cvar_t *coords;
+cvar_t *default_server;
 
 proxy_static_t ps;
 
@@ -131,6 +132,8 @@ DWORD WINAPI FWD_proc(void *lpParameter)
 	countrycode		= Cvar_Get("countrycode",	"", CVAR_SERVERINFO);
 	city			= Cvar_Get("city",		"", CVAR_SERVERINFO);
 	coords			= Cvar_Get("coords",		"", CVAR_SERVERINFO);
+
+	default_server	= Cvar_Get("default_server", "", 0);
 
 	// register basic commands
 	Cmd_AddCommand("quit", Cmd_Quit_f);

--- a/src/main.c
+++ b/src/main.c
@@ -20,6 +20,7 @@ cvar_t *countrycode;
 cvar_t *city;
 cvar_t *coords;
 cvar_t *default_server;
+cvar_t *default_server_map;
 
 proxy_static_t ps;
 
@@ -134,6 +135,7 @@ DWORD WINAPI FWD_proc(void *lpParameter)
 	coords			= Cvar_Get("coords",		"", CVAR_SERVERINFO);
 
 	default_server	= Cvar_Get("default_server", "", 0);
+	default_server_map = Cvar_Get("default_server_map", "", 0);
 
 	// register basic commands
 	Cmd_AddCommand("quit", Cmd_Quit_f);
@@ -158,7 +160,11 @@ DWORD WINAPI FWD_proc(void *lpParameter)
 	Cmd_StuffCmds(argc, argv);
 	Cbuf_Execute();
 
-	Sys_Printf("qwfwd: ready to rock at %s:%d\n", net_ip->string, net_port->integer);
+	{
+		int i;
+		for (i = 0; i < net_listener_count; i++)
+			Sys_Printf("qwfwd: ready to rock at %s:%d\n", net_ip->string, net_listeners[i].port);
+	}
 
 	while(!ps.wanttoexit)
 	{

--- a/src/net.c
+++ b/src/net.c
@@ -4,8 +4,11 @@
 
 cvar_t				*net_ip;
 cvar_t				*net_port;
+cvar_t				*net_ports;
 
 int					net_socket;
+net_listener_t		net_listeners[MAX_NET_LISTENERS];
+int					net_listener_count;
 struct sockaddr_in	net_from;
 int					net_from_socket;
 sizebuf_t			net_message;
@@ -162,6 +165,19 @@ qbool NET_GetSockAddrIn_ByHostAndPort(struct sockaddr_in *address, const char *h
 	return true;
 }
 
+int NET_GetListenerPort(int socket)
+{
+	int i;
+
+	for (i = 0; i < net_listener_count; i++)
+	{
+		if (net_listeners[i].socket == socket)
+			return net_listeners[i].port;
+	}
+
+	return 0;
+}
+
 //=============================================================================
 // return true if adresses equal
 qbool NET_CompareAddress(struct sockaddr_in *a, struct sockaddr_in *b)
@@ -266,10 +282,79 @@ void Netchan_OutOfBandPrint(int s, struct sockaddr_in *adr, const char *format, 
 NET_Init
 ====================
 */
+static int NET_ParsePortNumber(const char *value)
+{
+	char *end;
+	long port;
+
+	if (!value || !value[0])
+		return 0;
+
+	port = strtol(value, &end, 10);
+	if (*end || port < 1 || port > 65535)
+		return 0;
+
+	return (int)port;
+}
+
+static void NET_AddListenerPort(int port)
+{
+	int i;
+
+	for (i = 0; i < net_listener_count; i++)
+	{
+		if (net_listeners[i].port == port)
+			return;
+	}
+
+	if (net_listener_count >= MAX_NET_LISTENERS)
+		Sys_Error("NET_Init: too many listening ports (maximum %d)", MAX_NET_LISTENERS);
+
+	net_listeners[net_listener_count].socket = INVALID_SOCKET;
+	net_listeners[net_listener_count].port = port;
+	net_listener_count++;
+}
+
+static void NET_ParseListenerPorts(const char *value)
+{
+	char *ports, *token;
+
+	ports = Sys_strdup(value);
+	for (token = strtok(ports, " ,"); token; token = strtok(NULL, " ,"))
+	{
+		char *dash = strchr(token, '-');
+		int first, last, port;
+
+		if (dash)
+		{
+			if (strchr(dash + 1, '-'))
+				Sys_Error("NET_Init: invalid port range '%s'", token);
+
+			*dash = 0;
+			first = NET_ParsePortNumber(token);
+			last = NET_ParsePortNumber(dash + 1);
+			if (!first || !last || last < first)
+				Sys_Error("NET_Init: invalid port range '%s-%s'", token, dash + 1);
+
+			for (port = first; port <= last; port++)
+				NET_AddListenerPort(port);
+		}
+		else
+		{
+			port = NET_ParsePortNumber(token);
+			if (!port)
+				Sys_Error("NET_Init: invalid port '%s'", token);
+			NET_AddListenerPort(port);
+		}
+	}
+	Sys_free(ports);
+}
+
 void NET_Init (void)
 {
 	char *ip = (*ps.params.ip) ? ps.params.ip : "0.0.0.0";
 	char port[64] = {0};
+	int i;
 
 	snprintf(port, sizeof(port), "%d", 	ps.params.port ? ps.params.port : QWFWD_DEFAULT_PORT);
 
@@ -279,9 +364,15 @@ void NET_Init (void)
 		net_ip	 = Cvar_Get("net_ip",	  ip, CVAR_NOSET);
 
 	if (ps.params.port) // if cmd line - force it, so we have priority over cfg
+	{
 		net_port = Cvar_FullSet("net_port",	port, CVAR_NOSET);
+		net_ports = Cvar_FullSet("net_ports", "", CVAR_NOSET);
+	}
 	else
+	{
 		net_port = Cvar_Get("net_port",		port, CVAR_NOSET);
+		net_ports = Cvar_Get("net_ports",	"", CVAR_NOSET);
+	}
 
 #ifdef _WIN32
 	{
@@ -292,8 +383,27 @@ void NET_Init (void)
 	}
 #endif
 
-	if ((net_socket = NET_UDP_OpenSocket(net_ip->string, net_port->integer, true)) == INVALID_SOCKET)
-		Sys_Error("NET_Init: failed to initialize socket");
+	net_listener_count = 0;
+	memset(net_listeners, 0, sizeof(net_listeners));
+
+	if (net_ports->string[0])
+		NET_ParseListenerPorts(net_ports->string);
+	else
+		NET_AddListenerPort(net_port->integer);
+
+	if (!net_listener_count)
+		Sys_Error("NET_Init: no listening ports configured");
+
+	for (i = 0; i < net_listener_count; i++)
+	{
+		net_listeners[i].socket = NET_UDP_OpenSocket(net_ip->string, net_listeners[i].port, true);
+		if (net_listeners[i].socket == INVALID_SOCKET)
+			Sys_Error("NET_Init: failed to initialize socket on %s:%d", net_ip->string, net_listeners[i].port);
+	}
+
+	net_socket = net_listeners[0].socket;
+	snprintf(port, sizeof(port), "%d", net_listeners[0].port);
+	Cvar_ForceSet("net_port", port);
 
 	// init the message buffer
 	SZ_InitEx(&net_message, net_message_buffer, sizeof(net_message_buffer), false);

--- a/src/peer.c
+++ b/src/peer.c
@@ -7,13 +7,13 @@
 peer_t *peers = NULL;
 static int userid = 0;
 
-peer_t	*FWD_peer_by_addr(struct sockaddr_in *from)
+peer_t	*FWD_peer_by_addr(struct sockaddr_in *from, int listener_socket)
 {
 	peer_t *p;
 
 	for (p = peers; p; p = p->next)
 	{
-		if (NET_CompareAddress(&p->from, from))
+		if (p->listener_socket == listener_socket && NET_CompareAddress(&p->from, from))
 			return p;
 	}
 
@@ -31,7 +31,7 @@ static int parse_color(const char *userinfo, const char *key)
 	return (color < 0) ? 0 : ((color > 16) ? 16 : color);
 }
 
-peer_t	*FWD_peer_new(const char *remote_host, int remote_port, struct sockaddr_in *from, const char *userinfo, int qport, protocol_t proto, qbool link)
+peer_t	*FWD_peer_new(const char *remote_host, int remote_port, struct sockaddr_in *from, int listener_socket, const char *userinfo, int qport, protocol_t proto, qbool link)
 {
 	peer_t *p;
 	struct sockaddr_in to;
@@ -49,7 +49,7 @@ peer_t	*FWD_peer_new(const char *remote_host, int remote_port, struct sockaddr_i
 		return NULL;
 
 	// we probably already have such peer, reuse it then
-	p = FWD_peer_by_addr( from );
+	p = FWD_peer_by_addr(from, listener_socket);
 
 	// next check for NEW peer only
 	if ( !p )
@@ -69,6 +69,7 @@ peer_t	*FWD_peer_new(const char *remote_host, int remote_port, struct sockaddr_i
 	p->s		= ( new_peer ) ? s : p->s; // reuse socket in case of reusing
 	p->from		= *from;
 	p->to		= to;
+	p->listener_socket = listener_socket;
 	p->ps		= ( !new_peer && proto == pr_q3 ) ? p->ps : ps_challenge; // do not reset state for q3 in case of peer reusing
 	p->qport	= qport;
 	p->proto	= proto;
@@ -181,19 +182,85 @@ static void FWD_check_drop(void)
 	}
 }
 
+static void FWD_read_listener(int listener_socket)
+{
+	qbool connectionless;
+	int cnt;
+	peer_t *p;
+
+	for (;;)
+	{
+		if (!NET_GetPacket(listener_socket, &net_message))
+			break;
+
+		// check for bans.
+		if (SV_IsBanned(&net_from))
+			continue;
+
+		if (net_message.cursize == 1 && net_message.data[0] == A2A_ACK)
+		{
+			QRY_SV_PingReply();
+			continue;
+		}
+
+		MSG_BeginReading();
+		connectionless = (MSG_ReadLong() == -1);
+
+		if (connectionless)
+		{
+			if (MSG_BadRead())
+				continue;
+
+			if (!SV_ConnectionlessPacket())
+				continue; // seems we do not need forward it
+		}
+
+		p = FWD_peer_by_addr(&net_from, listener_socket);
+		if (!p)
+			continue;
+
+		// forward data to the server/proxy
+		if (p->ps >= ps_connected)
+		{
+			cnt = 1; // one packet by default
+
+			// check for "drop" aka client disconnect,
+			// first 10 bytes for NON connectionless packet is netchan related shit in QW
+			if (p->proto == pr_qw && !connectionless && net_message.cursize > 10 && net_message.data[10] == clc_stringcmd)
+			{
+				if (!strcmp((char*)net_message.data + 10 + 1, "drop"))
+				{
+					p->ps = ps_drop; // drop peer ASAP
+					cnt = 3; // send few packets due to possibile packet lost
+				}
+			}
+
+			for ( ; cnt > 0; cnt--)
+				NET_SendPacket(p->s, net_message.cursize, net_message.data, &p->to);
+		}
+
+		time(&p->last);
+	}
+}
+
 static void FWD_network_update(void)
 {
 	fd_set rfds;
 	struct timeval tv;
 	int retval;
-	int i1;
+	int i, i1;
 	peer_t *p;
 
 	FD_ZERO(&rfds);
 
-	// select on main server socket
-	FD_SET(net_socket, &rfds);
-	i1 = net_socket + 1;
+	// select on all server sockets
+	i1 = 0;
+	for (i = 0; i < net_listener_count; i++)
+	{
+		FD_SET(net_listeners[i].socket, &rfds);
+		if (net_listeners[i].socket >= i1)
+			i1 = net_listeners[i].socket + 1;
+	}
 
 	for (p = peers; p; p = p->next)
 	{
@@ -239,76 +306,11 @@ retry:
 	if (retval <= 0)
 		return;
 
-	// if we have input packet on main server/proxy socket, then read it
-	if(FD_ISSET(net_socket, &rfds))
+	// read packets from every configured server/proxy socket
+	for (i = 0; i < net_listener_count; i++)
 	{
-		qbool connectionless;
-		int cnt;
-
-		// read it
-		for(;;)
-		{
-			if (!NET_GetPacket(net_socket, &net_message))
-				break;
-
-			// check for bans.
-			if (SV_IsBanned(&net_from))
-				continue;
-
-			if (net_message.cursize == 1 && net_message.data[0] == A2A_ACK)
-			{
-				QRY_SV_PingReply();
-
-				continue;
-			}
-
-			MSG_BeginReading();
-			connectionless = (MSG_ReadLong() == -1);
-
-			if (connectionless)
-			{
-				if (MSG_BadRead())
-					continue;
-
-				if (!SV_ConnectionlessPacket())
-					continue; // seems we do not need forward it
-			}
-
-			// search in peers
-			for (p = peers; p; p = p->next)
-			{
-				// we have this peer already, so forward/send packet to remote server
-				if (NET_CompareAddress(&p->from, &net_from))
-					break;
-			}
-
-			// peer was not found
-			if (!p)
-				continue;
-
-			// forward data to the server/proxy
-			if (p->ps >= ps_connected)
-			{
-				cnt = 1; // one packet by default
-
-				// check for "drop" aka client disconnect,
-				// first 10 bytes for NON connectionless packet is netchan related shit in QW
-				if (p->proto == pr_qw && !connectionless && net_message.cursize > 10 && net_message.data[10] == clc_stringcmd)
-				{
-					if (!strcmp((char*)net_message.data + 10 + 1, "drop"))
-					{
-//						Sys_Printf("peer drop detected\n");
-						p->ps = ps_drop; // drop peer ASAP
-						cnt = 3; // send few packets due to possibile packet lost
-					}
-				}
-
-				for ( ; cnt > 0; cnt--)
-					NET_SendPacket(p->s, net_message.cursize, net_message.data, &p->to);
-			}
-
-			time(&p->last);
-		}
+		if (FD_ISSET(net_listeners[i].socket, &rfds))
+			FWD_read_listener(net_listeners[i].socket);
 	}
 
 	// now lets check peers sockets, perhaps we have input packets too
@@ -339,12 +341,12 @@ retry:
 					if (!CL_ConnectionlessPacket(p))
 						continue; // seems we do not need forward it
 
-					NET_SendPacket(net_socket, net_message.cursize, net_message.data, &p->from);
+					NET_SendPacket(p->listener_socket, net_message.cursize, net_message.data, &p->from);
 					continue;
 				}
 
 				if (p->ps >= ps_connected)
-					NET_SendPacket(net_socket, net_message.cursize, net_message.data, &p->from);
+					NET_SendPacket(p->listener_socket, net_message.cursize, net_message.data, &p->from);
 
 // qqshka: commented out
 //				time(&p->last);

--- a/src/qwfwd.h
+++ b/src/qwfwd.h
@@ -225,6 +225,7 @@ extern proxy_static_t ps;
 
 extern cvar_t *developer, *maxclients, *hostname;
 extern cvar_t *hostport, *countrycode, *city, *coords;
+extern cvar_t *default_server;
 
 //
 // token.c

--- a/src/qwfwd.h
+++ b/src/qwfwd.h
@@ -155,6 +155,7 @@ typedef struct peer
 	int qport;						// qport
 	struct sockaddr_in from;		// client addr
 	struct sockaddr_in to;			// remote addr
+	int listener_socket;				// local socket used by this client
 	int s;							// socket, used for connection to remote host
 	peer_state_t ps;				// peer state
 	protocol_t	proto;				// which protocol we use
@@ -225,7 +226,7 @@ extern proxy_static_t ps;
 
 extern cvar_t *developer, *maxclients, *hostname;
 extern cvar_t *hostport, *countrycode, *city, *coords;
-extern cvar_t *default_server;
+extern cvar_t *default_server, *default_server_map;
 
 //
 // token.c
@@ -263,8 +264,8 @@ qbool			FS_SafePath(const char *in);
 
 extern	peer_t		*peers;
 
-peer_t		*FWD_peer_by_addr(struct sockaddr_in *from);
-peer_t		*FWD_peer_new(const char *remote_host, int remote_port, struct sockaddr_in *from, const char *userinfo, int qport, protocol_t proto, qbool link);
+peer_t		*FWD_peer_by_addr(struct sockaddr_in *from, int listener_socket);
+peer_t		*FWD_peer_new(const char *remote_host, int remote_port, struct sockaddr_in *from, int listener_socket, const char *userinfo, int qport, protocol_t proto, qbool link);
 void		FWD_update_peers(void);
 
 int			FWD_peers_count(void);
@@ -379,9 +380,19 @@ double			Sys_DoubleTime (void);
 // net.c
 //
 
-extern	cvar_t			*net_ip, *net_port;
+#define MAX_NET_LISTENERS 32
+
+typedef struct net_listener
+{
+	int socket;
+	int port;
+} net_listener_t;
+
+extern	cvar_t			*net_ip, *net_port, *net_ports;
 
 extern	int			net_socket;
+extern	net_listener_t	net_listeners[MAX_NET_LISTENERS];
+extern	int			net_listener_count;
 extern	struct sockaddr_in	net_from;
 extern	int			net_from_socket;
 extern	sizebuf_t		net_message;
@@ -390,6 +401,7 @@ int				NET_GetPacket(int s, sizebuf_t *msg);
 void				NET_SendPacket(int s, int length, const void *data, struct sockaddr_in *to);
 int				NET_UDP_OpenSocket(const char *ip, int port, qbool do_bind);
 qbool				NET_GetSockAddrIn_ByHostAndPort(struct sockaddr_in *address, const char *host, int port);
+int				NET_GetListenerPort(int socket);
 
 char				*NET_BaseAdrToString (struct sockaddr_in *a, char *buf, size_t bufsize);
 char				*NET_AdrToString (struct sockaddr_in *a, char *buf, size_t bufsize);

--- a/src/svc.c
+++ b/src/svc.c
@@ -27,6 +27,7 @@ typedef struct
 	int						challenge;
 	time_t					time;
 	protocol_t				proto;
+	int						listener_socket;
 } challenge_t;
 
 static challenge_t		challenges[MAX_CHALLENGES];	// to prevent invalid IPs from connecting
@@ -38,7 +39,7 @@ static unsigned int FindChallengeForAddr(struct sockaddr_in *addr)
 
 	for (i = 0; i < MAX_CHALLENGES; i++)
 	{
-		if (NET_CompareAddress(addr, &challenges[i].adr))
+		if (challenges[i].listener_socket == net_from_socket && NET_CompareAddress(addr, &challenges[i].adr))
 		{
 			break; // found
 		}
@@ -96,6 +97,7 @@ static void SVC_GetChallenge ( protocol_t proto )
 		challenges[i].challenge = (rand() << 16) ^ rand();
 		challenges[i].adr		= net_from;
 		challenges[i].time		= time(NULL);
+		challenges[i].listener_socket = net_from_socket;
 	}
 
 	// overwrite proto in any case!
@@ -103,7 +105,7 @@ static void SVC_GetChallenge ( protocol_t proto )
 
 	if ( challenges[i].proto == pr_q3 )
 	{
-		peer_t *p = FWD_peer_by_addr( &net_from );
+		peer_t *p = FWD_peer_by_addr(&net_from, net_from_socket);
 		if ( p && p->ps == ps_connected )
 		{
 			Sys_DPrintf("challenge q3 overwrite trick!\n");
@@ -181,14 +183,50 @@ static qbool CheckUserinfo( char *userinfobuf, unsigned int bufsize, char *useri
 	return true;
 }
 
+static qbool SVC_GetDefaultServer(char *server, size_t server_size, int listener_port, const char **source)
+{
+	char map[MAX_COM_TOKEN];
+	char *entry;
+
+	strlcpy(map, default_server_map->string, sizeof(map));
+	for (entry = strtok(map, " ,"); entry; entry = strtok(NULL, " ,"))
+	{
+		char *equals = strchr(entry, '=');
+		char *end;
+		long port;
+
+		if (!equals || !equals[1])
+			continue;
+
+		*equals = 0;
+		port = strtol(entry, &end, 10);
+		if (*end || port < 1 || port > 65535 || port != listener_port)
+			continue;
+
+		strlcpy(server, equals + 1, server_size);
+		*source = "default_server_map";
+		return true;
+	}
+
+	if (default_server->string[0])
+	{
+		strlcpy(server, default_server->string, server_size);
+		*source = "default_server";
+		return true;
+	}
+
+	return false;
+}
+
 static void SVC_DirectConnect (void)
 {
 	unsigned int i = FindChallengeForAddr(&net_from);
 
 	char userinfo[MAX_INFO_STRING], prx[MAX_INFO_KEY * 4 /* we allow huge size for prx */], *at;
 	qbool using_default_server = false;
+	const char *default_source = NULL;
 	peer_t *p = NULL;
-	int qport, port, challenge;
+	int qport, port, challenge, listener_port;
 	protocol_t proto;
 
 	if ( i >= MAX_CHALLENGES )
@@ -248,9 +286,9 @@ static void SVC_DirectConnect (void)
 	Info_ValueForKey(userinfo, QWFWD_PRX_KEY, prx, sizeof(prx));
 	if (!prx[0])
 	{
-		if (default_server->string[0])
+		listener_port = NET_GetListenerPort(net_from_socket);
+		if (SVC_GetDefaultServer(prx, sizeof(prx), listener_port, &default_source))
 		{
-			strlcpy(prx, default_server->string, sizeof(prx));
 			using_default_server = true;
 		}
 		else if ( proto == pr_qw )
@@ -284,13 +322,13 @@ static void SVC_DirectConnect (void)
 	}
 	else
 	{
-		port = ( proto == pr_qw ) ? 27500 : 27960;
+		port = using_default_server ? NET_GetListenerPort(net_from_socket) : (( proto == pr_qw ) ? 27500 : 27960);
 	}
 
-	if (port < 1)
+	if (port < 1 || port > 65535)
 	{
 		Netchan_OutOfBandPrint (net_from_socket, &net_from, "%c\nport number in %s is invalid\n", A2C_PRINT,
-			using_default_server ? "default_server" : QWFWD_PRX_KEY " userinfo key");
+			using_default_server ? default_source : QWFWD_PRX_KEY " userinfo key");
 		return; // something wrong with port
 	}
 
@@ -300,7 +338,7 @@ static void SVC_DirectConnect (void)
 	// build a new connection
 
 	// this was new peer, lets register it then
-	if ((p = FWD_peer_new(prx, port, &net_from, userinfo, qport, proto, true)))
+	if ((p = FWD_peer_new(prx, port, &net_from, net_from_socket, userinfo, qport, proto, true)))
 	{
 		Sys_DPrintf("peer %s:%d added or reused\n", inet_ntoa(net_from.sin_addr), (int)ntohs(net_from.sin_port));
 	}

--- a/src/svc.c
+++ b/src/svc.c
@@ -186,6 +186,7 @@ static void SVC_DirectConnect (void)
 	unsigned int i = FindChallengeForAddr(&net_from);
 
 	char userinfo[MAX_INFO_STRING], prx[MAX_INFO_KEY * 4 /* we allow huge size for prx */], *at;
+	qbool using_default_server = false;
 	peer_t *p = NULL;
 	int qport, port, challenge;
 	protocol_t proto;
@@ -247,15 +248,21 @@ static void SVC_DirectConnect (void)
 	Info_ValueForKey(userinfo, QWFWD_PRX_KEY, prx, sizeof(prx));
 	if (!prx[0])
 	{
-		if ( proto == pr_qw )
+		if (default_server->string[0])
+		{
+			strlcpy(prx, default_server->string, sizeof(prx));
+			using_default_server = true;
+		}
+		else if ( proto == pr_qw )
 		{
 			Netchan_OutOfBandPrint (net_from_socket, &net_from, "%c\n" QWFWD_PRX_KEY " userinfo key is not set\n", A2C_PRINT);
+			return; // no proxy or default server set
 		}
 		else
 		{
 			Netchan_OutOfBandPrint (net_from_socket, &net_from, "print\n" QWFWD_PRX_KEY " userinfo key is not set\n");
+			return; // no proxy or default server set
 		}
-		return; // no proxy set
 	}
 
 	// check chaining
@@ -282,7 +289,8 @@ static void SVC_DirectConnect (void)
 
 	if (port < 1)
 	{
-		Netchan_OutOfBandPrint (net_from_socket, &net_from, "%c\nport number in " QWFWD_PRX_KEY " userinfo key is invalid\n", A2C_PRINT);
+		Netchan_OutOfBandPrint (net_from_socket, &net_from, "%c\nport number in %s is invalid\n", A2C_PRINT,
+			using_default_server ? "default_server" : QWFWD_PRX_KEY " userinfo key");
 		return; // something wrong with port
 	}
 

--- a/src/svc.c
+++ b/src/svc.c
@@ -77,10 +77,11 @@ static void SVC_GetChallenge ( protocol_t proto )
 	oldest = 0;
 	oldestTime = 0x7fffffff;
 
-	// see if we already have a challenge for this ip
+	// see if we already have a challenge for this ip on this listener
 	for (i = 0 ; i < MAX_CHALLENGES; i++)
 	{
-		if (NET_CompareAddress(&net_from, &challenges[i].adr))
+		if (challenges[i].listener_socket == net_from_socket &&
+			NET_CompareAddress(&net_from, &challenges[i].adr))
 			break;
 
 		if (challenges[i].time < oldestTime)


### PR DESCRIPTION
## Summary

This change adds configurable default destinations for clients that connect directly to QWFWD without a `prx` userinfo key. It also allows one QWFWD process to listen on multiple UDP ports and route each incoming port to the matching or explicitly configured destination port.

The connection is established through QWFWD's normal proxy path. The client is not redirected with a `connect` command.

## Motivation

Normally, players need to configure `cl_proxyaddr` or provide the `prx` userinfo key before connecting through QWFWD. This makes it difficult to expose regional proxy addresses that behave like regular QuakeWorld servers.

For example, the following regional proxy addresses are in use:

- `eu.qwtf.net` — proxy to `qwtf.net` for players in Europe
- `ru.qwtf.net` — proxy to `qwtf.net` for players in Russia

With `default_server`, players can connect directly to a regional address without changing their client configuration. Multi-port support lets the same proxy preserve QuakeWorld server ports instead of requiring one QWFWD process per port.

## Configuration

Preserve the incoming port automatically:

```cfg
set net_ip 188.120.226.217
set net_ports "27500 27501"
set default_server qwtf.net
```

Routes:

```text
188.120.226.217:27500 -> qwtf.net:27500
188.120.226.217:27501 -> qwtf.net:27501
```

Override an individual destination with `default_server_map`:

```cfg
set default_server_map "27501=qwtf.net:27502"
```

This changes the second route to:

```text
188.120.226.217:27501 -> qwtf.net:27502
```

`net_ports` accepts space-separated or comma-separated ports and ranges such as `27500-27510`. Multiple map entries can be separated by spaces.

## Backward compatibility

- Existing `net_port` configurations continue to work when `net_ports` is empty.
- `default_server host:port` continues to route every listener to that explicit destination port unless a map entry overrides it.
- An explicitly configured client `prx` value continues to take precedence.
- Proxy chaining behavior is unchanged.
- If neither `default_server` nor a matching map entry is configured, the existing `prx userinfo key is not set` error is preserved.

## Implementation details

- QWFWD maintains a bounded collection of listening sockets instead of only one server socket.
- Each peer and challenge is associated with the listener socket on which it arrived.
- Replies to a client are sent from that same listener socket, preserving the expected source port.
- Master queries and heartbeats continue to use the first configured listener.

## Documentation

The new variables and routing behavior are documented in:

- `README.md`
- `resources/example-configs/qwfwd.cfg`

## Validation

- Same-port route: `31200 -> 31200`.
- Per-port override: `31201 -> 31202`.
- Explicit `prx` takes precedence over default routing.
- Client responses originate from the listener port used by the client.
- Legacy `net_port + default_server host:port` configuration remains functional.
- The project builds successfully for Windows and Linux amd64.
